### PR TITLE
Paintings fixed math

### DIFF
--- a/src/game/paintings.c
+++ b/src/game/paintings.c
@@ -191,8 +191,6 @@ struct Painting **sPaintingGroups[] = {
 s16 gPaintingUpdateCounter = 1;
 s16 gLastPaintingUpdateCounter = 0;
 
-//struct FixedPainting* fixedPainting;
-
 /**
  * Stop paintings in paintingGroup from rippling if their id is different from *idptr.
  */

--- a/src/game/paintings.h
+++ b/src/game/paintings.h
@@ -116,6 +116,7 @@ struct Painting {
     f32 size;
 };
 
+#ifdef TARGET_NDS
 struct FixedPainting {
     s32 currRippleMag;
     s32 currRippleRate;
@@ -125,6 +126,7 @@ struct FixedPainting {
     s32 rippleY;
     s32 size;
 };
+#endif
 
 /**
  * Contains the position and normal of a vertex in the painting's generated mesh.

--- a/src/game/paintings.h
+++ b/src/game/paintings.h
@@ -116,6 +116,16 @@ struct Painting {
     f32 size;
 };
 
+struct FixedPainting {
+    s32 currRippleMag;
+    s32 currRippleRate;
+    s32 dispersionFactor;
+    s32 rippleTimer;
+    s32 rippleX;
+    s32 rippleY;
+    s32 size;
+};
+
 /**
  * Contains the position and normal of a vertex in the painting's generated mesh.
  */

--- a/src/nds/nds_renderer.c
+++ b/src/nds/nds_renderer.c
@@ -81,10 +81,6 @@ static uint16_t fog_max;
 static int no_texture;
 static int frame_count;
 
-static Vtx_t* vertex_batch[32 * 3];
-static uint8_t num_verts_batched = 0;
-
-
 struct Sprite sprites[MAX_SPRITES];
 
 struct {
@@ -472,20 +468,26 @@ static void g_vtx(Gwords *words) {
 }
 
 static void g_tri1(Gwords *words) {
-    // Batch a triangle to render
-    vertex_batch[num_verts_batched++] = &vertex_buffer[((words->w0 >> 16) & 0xFF) >> 1].v;
-    vertex_batch[num_verts_batched++] = &vertex_buffer[((words->w0 >>  8) & 0xFF) >> 1].v;
-    vertex_batch[num_verts_batched++] = &vertex_buffer[((words->w0 >>  0) & 0xFF) >> 1].v;
+    // Draw a triangle
+    const Vtx_t *v[] = {
+        &vertex_buffer[((words->w0 >> 16) & 0xFF) >> 1].v,
+        &vertex_buffer[((words->w0 >>  8) & 0xFF) >> 1].v,
+        &vertex_buffer[((words->w0 >>  0) & 0xFF) >> 1].v
+    };
+    draw_vertices(v, 3);
 }
 
 static void g_tri2(Gwords *words) {
-    // Batch triangles to render
-    vertex_batch[num_verts_batched++] = &vertex_buffer[((words->w0 >> 16) & 0xFF) >> 1].v;
-    vertex_batch[num_verts_batched++] = &vertex_buffer[((words->w0 >>  8) & 0xFF) >> 1].v;
-    vertex_batch[num_verts_batched++] = &vertex_buffer[((words->w0 >>  0) & 0xFF) >> 1].v;
-    vertex_batch[num_verts_batched++] = &vertex_buffer[((words->w1 >> 16) & 0xFF) >> 1].v;
-    vertex_batch[num_verts_batched++] = &vertex_buffer[((words->w1 >>  8) & 0xFF) >> 1].v;
-    vertex_batch[num_verts_batched++] = &vertex_buffer[((words->w1 >>  0) & 0xFF) >> 1].v;
+    // Draw two triangles at once
+    const Vtx_t *v[] = {
+        &vertex_buffer[((words->w0 >> 16) & 0xFF) >> 1].v,
+        &vertex_buffer[((words->w0 >>  8) & 0xFF) >> 1].v,
+        &vertex_buffer[((words->w0 >>  0) & 0xFF) >> 1].v,
+        &vertex_buffer[((words->w1 >> 16) & 0xFF) >> 1].v,
+        &vertex_buffer[((words->w1 >>  8) & 0xFF) >> 1].v,
+        &vertex_buffer[((words->w1 >>  0) & 0xFF) >> 1].v
+    };
+    draw_vertices(v, 6);
 }
 
 static void g_texture(Gwords *words) {
@@ -936,12 +938,6 @@ static void execute(Gfx* cmd) {
     // Interpret a list of Fast3DEX2 commands using the DS hardware
     while (true) {
         const uint8_t opcode = cmd->words.w0 >> 24;
-
-        // Draw the batched verticies
-        if ((opcode != G_TRI1 && opcode != G_TRI2 && num_verts_batched > 0) || num_verts_batched >= 90) {
-            draw_vertices(vertex_batch, num_verts_batched);
-            num_verts_batched = 0;
-        }
 
         switch (opcode) {
             case G_VTX:            g_vtx(&cmd->words);            break;


### PR DESCRIPTION
Vertex displacement math is very slow, it currently uses floating point math. Per vertex it runs 16 floating point operations. (including a square root) This implementation only affects the graphical rendering of paintings and "floor paintings" like HMC and CotMC.

This PR converts all the values of the painting used in the vertex displacement math once per frame and operates on them all. This change makes the frame rate in HMC's room in the basement stay below 33 ms frame time. Thus staying at 30 fps. This affects the wobble effect when bonking or jumping into paintings too.

This change does not preserve the build for non DSi targets.